### PR TITLE
Vault and Policy patch for Create User

### DIFF
--- a/Assign Policy
+++ b/Assign Policy
@@ -11,6 +11,15 @@ $policyID = ""
 
 # --- DO NOT MODIFY ANYTHING BELOW THIS LINE --- #
 
+# Get current user profile and find policyID index
 $UserProfile = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/get-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu}
-$PolicyIndex = $UserProfile.IndexOf('PolicyID"') + 'PolicyID":"'.length
+$PolicyStartIndex = $UserProfile.IndexOf('PolicyID"') + 'PolicyID":"'.length
+$PolicyEndIndex = $UserProfile.IndexOf('"', $PolicyStartIndex)
 
+# Splice the profile into a beginning and end part
+$ProfileFront = $UserProfile.Substring(0, $PolicyStartIndex)
+$ProfileBack = $UserProfile.Substring($PolicyEndIndex, ($UserProfile.length - $PolicyEndIndex))
+
+# Insert new policy ID and send to server
+$UserProfile = $ProfileFront + $policyID + $ProfileBack
+$Result = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/set-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; ProfileData="${UserProfile}"} | select Content

--- a/Assign Policy
+++ b/Assign Policy
@@ -1,0 +1,16 @@
+Import-Module $env:SyncroModule
+
+# --- EDIT SERVER INFO BELOW --- #
+# --- Need help? Email support@magnusbox.com --- #
+
+$username = "User"
+$password = "Password"
+$server = "Server"
+$policyID = ""
+# To find policyID, copy the end text from the web dashboard when viewing the policy
+
+# --- DO NOT MODIFY ANYTHING BELOW THIS LINE --- #
+
+$UserProfile = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/get-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu}
+$PolicyIndex = $UserProfile.IndexOf('PolicyID"') + 'PolicyID":"'.length
+

--- a/Assign Policy
+++ b/Assign Policy
@@ -13,6 +13,8 @@ $policyID = ""
 
 # Get current user profile and find policyID index
 $UserProfile = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/get-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu}
+$UserProfile = $UserProfile.Content
+Write-Host $UserProfile
 $PolicyStartIndex = $UserProfile.IndexOf('PolicyID"') + 'PolicyID":"'.length
 $PolicyEndIndex = $UserProfile.IndexOf('"', $PolicyStartIndex)
 
@@ -22,4 +24,5 @@ $ProfileBack = $UserProfile.Substring($PolicyEndIndex, ($UserProfile.length - $P
 
 # Insert new policy ID and send to server
 $UserProfile = $ProfileFront + $policyID + $ProfileBack
-$Result = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/set-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; ProfileData="${UserProfile}"} | select Content
+$Result = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/set-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; ProfileData="${UserProfile}"}
+Write-Host $Result.Content

--- a/Create New User
+++ b/Create New User
@@ -6,7 +6,18 @@ Import-Module $env:SyncroModule
 $username = "User"
 $password = "Password"
 $server= "Server"
+$vault = "US"
+# /\   "US" = United States Vault; "EU" = European Union Vault
+
 
 # --- DO NOT MODIFY ANYTHING BELOW THIS LINE ---
 
+# Create user
 Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/add-user" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; TargetPassword=$mbp; StoreRecoveryCode="1"} | select Content
+
+# Request storage vault
+$vaultId = "bj2NYxeAXvUaUQRi6o2y9PEO9YBPtiOrQFkSLFOUSIo"
+If ($vault -eq "EU") {
+    $vaultId = "qHY4tSIVMN8hEQ6opXvdwZfr9Pt9n2XOK0gdRxLEqss"
+}
+Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/request-storage-vault" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; StorageProvider="${vaultId}"} | select Content

--- a/Create New User
+++ b/Create New User
@@ -1,19 +1,19 @@
 Import-Module $env:SyncroModule
 
-# --- EDIT SERVER INFO BELOW ---
-# --- Need help? Email support@magnusbox.com ---
+# --- EDIT SERVER INFO BELOW --- #
+# --- Need help? Email support@magnusbox.com --- #
 
 $username = "User"
 $password = "Password"
 $server= "Server"
 
-# --- Post-Create Processing ---
-$assignPolicy = $true;
-$assignVault = $true;
+# --- Post-Create Processing --- #
+$assignPolicy = $true
+$assignVault = $true
 
 
 
-# --- DO NOT MODIFY ANYTHING BELOW THIS LINE ---
+# --- DO NOT MODIFY ANYTHING BELOW THIS LINE --- #
 
 # Create user
 Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/add-user" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; TargetPassword=$mbp; StoreRecoveryCode="1"} | select Content
@@ -56,7 +56,23 @@ if($assignPolicy -eq $true) {
 
     # Insert new policy ID and send to server
     $UserProfile = $ProfileFront + $policyID + $ProfileBack
-    $Result = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/set-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; ProfileData="${UserProfile}"}
-    
+    $PolicyResult = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/set-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; ProfileData="${UserProfile}"}
+    $PolicyResult = PolicyResult.Content
 }
+
+# Vault selection logic
+if($assignVault -eq $true) {
+    
+    # Grab the ID of the first (and likely only) vault
+    $VaultList = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/request-storage-vault-providers" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"}
+    $VaultList = $VaultList.Content
+    $VaultIdStart = $VaultList.IndexOf('{"') + '{"'.length
+    $VaultIdEnd = $VaultList.IndexOf('":"', $VaultIdStart)
+    $VaultId = $VaultList.Substring($VaultIdStart, ($VaultIdEnd - $VaultIdStart))
+    
+    # Assign this vault to the user
+    $VaultResult = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/request-storage-vault" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; StorageProvider="${VaultId}"}
+    $VaultResult = $VaultResult.Content
+}
+
 

--- a/Create New User
+++ b/Create New User
@@ -16,7 +16,9 @@ $assignVault = $true
 # --- DO NOT MODIFY ANYTHING BELOW THIS LINE --- #
 
 # Create user
-Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/add-user" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; TargetPassword=$mbp; StoreRecoveryCode="1"} | select Content
+$UserResult = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/add-user" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; TargetPassword=$mbp; StoreRecoveryCode="1"}
+$UserResult = $UserResult.Content
+Write-Host $UserResult
 
 
 # NOTE: Local variables:  "${varName}"    Syncro variables: $globalVar
@@ -46,7 +48,6 @@ if($assignPolicy -eq $true) {
     # Get current user profile and find policyID index
     $UserProfile = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/get-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu}
     $UserProfile = $UserProfile.Content
-    Write-Host $UserProfile
     $PolicyStartIndex = $UserProfile.IndexOf('PolicyID"') + 'PolicyID":"'.length
     $PolicyEndIndex = $UserProfile.IndexOf('"', $PolicyStartIndex)
 
@@ -57,7 +58,15 @@ if($assignPolicy -eq $true) {
     # Insert new policy ID and send to server
     $UserProfile = $ProfileFront + $policyID + $ProfileBack
     $PolicyResult = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/set-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; ProfileData="${UserProfile}"}
-    $PolicyResult = PolicyResult.Content
+    $PolicyResult = $PolicyResult.Content
+    
+    # Let the user know if it was a success
+    if($PolicyResult.IndexOf('200') -ne -1) {
+        Write-Host "Default policy added successfully"
+    } else {
+        Write-Host "WARNING: Policy was not added to user! Response below:"
+        Write-Host $PolicyResult
+    }
 }
 
 # Vault selection logic
@@ -73,6 +82,13 @@ if($assignVault -eq $true) {
     # Assign this vault to the user
     $VaultResult = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/request-storage-vault" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; StorageProvider="${VaultId}"}
     $VaultResult = $VaultResult.Content
+    
+    # Log the status
+    if($VaultResult.IndexOf('200') -ne -1) {
+        Write-Host "Storage vault was created for the user."
+    } else {
+        Write-Host "WARNING: Vault unable to be created! Response below:"
+        Write-Host $VaultResult
+    }
 }
-
 

--- a/Create New User
+++ b/Create New User
@@ -8,8 +8,8 @@ $password = "Password"
 $server= "Server"
 
 # --- Post-Create Processing ---
-$policyID = "";
-$chooseStorageVault = true;
+$assignPolicy = $true;
+$assignVault = $true;
 
 
 
@@ -21,8 +21,42 @@ Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/add-user" -UseBas
 
 # NOTE: Local variables:  "${varName}"    Syncro variables: $globalVar
 
-# Choose policy (if given above)
-if($policyID.length -gt 0) {
-# TODO: get user profile, set the policy ID, and then set user profile
+# Choose policy (if they want it)
+if($assignPolicy -eq $true) {
+    
+    # Get a list of all of the policies
+    $PolicyList = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/list-full" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"}
+    $PolicyList = $PolicyList.Content
+    $DefaultIndex = $PolicyList.IndexOf('DefaultUserPolicy":true')
+    if($DefaultIndex -eq -1) {
+        Write-Host "No default policy specified. Unable to set"
+        break
+    }
+    
+    # Find the ID of the default policy by reversing string for backwards substring
+    $PolicyList = $PolicyList.Substring(0, $DefaultIndex)
+    $ReversedList = $PolicyList.ToCharArray()
+    [array]::Reverse($ReversedList)
+    $ReversedList = -join($ReversedList)
+    $IdStart = $ReversedList.IndexOf('cseD"{:"') + 'cseD"{:"'.length   # Search for {"Des (but backwards)
+    $IdEnd = $ReversedList.IndexOf('"', $IdStart)
+    # Subtract from length to translate from reversed list to proper order
+    $policyID = $PolicyList.Substring(($PolicyList.length - $IdEnd), ($IdEnd - $IdStart))
+    
+    # Get current user profile and find policyID index
+    $UserProfile = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/get-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu}
+    $UserProfile = $UserProfile.Content
+    Write-Host $UserProfile
+    $PolicyStartIndex = $UserProfile.IndexOf('PolicyID"') + 'PolicyID":"'.length
+    $PolicyEndIndex = $UserProfile.IndexOf('"', $PolicyStartIndex)
+
+    # Splice the profile into a beginning and end part
+    $ProfileFront = $UserProfile.Substring(0, $PolicyStartIndex)
+    $ProfileBack = $UserProfile.Substring($PolicyEndIndex, ($UserProfile.length - $PolicyEndIndex))
+
+    # Insert new policy ID and send to server
+    $UserProfile = $ProfileFront + $policyID + $ProfileBack
+    $Result = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/set-user-profile" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; ProfileData="${UserProfile}"}
+    
 }
 

--- a/Create New User
+++ b/Create New User
@@ -6,8 +6,11 @@ Import-Module $env:SyncroModule
 $username = "User"
 $password = "Password"
 $server= "Server"
-$vault = "US"
-# /\   "US" = United States Vault; "EU" = European Union Vault
+
+# --- Post-Create Processing ---
+$policyID = "";
+$chooseStorageVault = true;
+
 
 
 # --- DO NOT MODIFY ANYTHING BELOW THIS LINE ---
@@ -15,9 +18,11 @@ $vault = "US"
 # Create user
 Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/add-user" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; TargetPassword=$mbp; StoreRecoveryCode="1"} | select Content
 
-# Request storage vault
-$vaultId = "bj2NYxeAXvUaUQRi6o2y9PEO9YBPtiOrQFkSLFOUSIo"
-If ($vault -eq "EU") {
-    $vaultId = "qHY4tSIVMN8hEQ6opXvdwZfr9Pt9n2XOK0gdRxLEqss"
+
+# NOTE: Local variables:  "${varName}"    Syncro variables: $globalVar
+
+# Choose policy (if given above)
+if($policyID.length -gt 0) {
+# TODO: get user profile, set the policy ID, and then set user profile
 }
-Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/request-storage-vault" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"; TargetUser=$mbu; StorageProvider="${vaultId}"} | select Content
+

--- a/Create New User
+++ b/Create New User
@@ -25,7 +25,7 @@ Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/add-user" -UseBas
 if($assignPolicy -eq $true) {
     
     # Get a list of all of the policies
-    $PolicyList = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/list-full" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"}
+    $PolicyList = Invoke-Webrequest -Uri "https://${server}:${port}/api/v1/admin/policies/list-full" -UseBasicParsing -Method POST -Body @{Username="${username}"; AuthType="Password"; Password="${password}"}
     $PolicyList = $PolicyList.Content
     $DefaultIndex = $PolicyList.IndexOf('DefaultUserPolicy":true')
     if($DefaultIndex -eq -1) {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ These scripts require the use of the custom customer fields in Syncro.
 1. Click on Customers
 2. Select a customer
 3. Under custom fields, click edit
-4. Inpute a secure username and password in the "Magnus Box Password" & "Magnus Box Username" fields 
+4. Input a secure username and password in the "Magnus Box Password" & "Magnus Box Username" fields 
 5. Repeat this process for every customer that you would like to add to Magnus Box. 
 
 You will also need a dedicated Magnus Box API account setup for Syncro. You will use this to run the scripts. To have a dedicated API account setup, please email support@magnusbox.com and request a Syncro API user account.


### PR DESCRIPTION
Integrate default policy assignation and storage vault selection within the Create New User script. Also add a Assign Policy standalone script to easily change policy for a number of users.

@MagnusBoxMike Can you please review these changes and accept this pull request into the master branch if you believe it's ready to go?

Example Syncro output from new Create New User script:
![New-Create-User-Output](https://user-images.githubusercontent.com/12915796/100494727-6fcfe500-3112-11eb-8816-20310a86ab2e.png)
